### PR TITLE
Support mruby-2.0

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,8 @@
 MRuby::Gem::Specification.new('mruby-research') do |spec|
   spec.license = 'MIT'
   spec.author  = 'ksss <co000ri@gmail.com>'
+  if File.exist?(File.join(MRUBY_ROOT, 'mrbgems/mruby-metaprog'))
+    # for mruby-2.0+
+    spec.add_dependency 'mruby-metaprog', core: 'mruby-metaprog'
+  end
 end

--- a/src/mruby.c
+++ b/src/mruby.c
@@ -8,6 +8,7 @@
 #include <mruby/hash.h>
 #include <mruby/proc.h>
 #include <mruby/irep.h>
+#include <mruby/debug.h>
 #include <mruby/string.h>
 #include <mruby/array.h>
 #include <mruby/variable.h>
@@ -766,7 +767,7 @@ mrb_irep_class_filename(mrb_state *mrb, mrb_value self)
   mrb_value obj = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@obj"));
   mrb_irep *irep = mrb_proc_ptr(obj)->body.irep;
 
-  return mrb_str_new_cstr(mrb, irep->filename);
+  return mrb_str_new_cstr(mrb, mrb_debug_get_filename(irep, 0));
 }
 
 static mrb_value
@@ -777,10 +778,10 @@ mrb_irep_class_lines(mrb_state *mrb, mrb_value self)
   mrb_int iseq_no;
   mrb_value a = mrb_ary_new_capa(mrb, (mrb_int)irep->ilen);
 
-  if (!irep->lines)
-    return a;
   for (iseq_no = 0; iseq_no < irep->ilen; iseq_no++) {
-    mrb_ary_set(mrb, a, iseq_no, mrb_fixnum_value((mrb_int)irep->lines[iseq_no]));
+    mrb_int line = mrb_debug_get_line(irep, iseq_no);
+    if (line < 0) { break; }
+    mrb_ary_set(mrb, a, iseq_no, mrb_fixnum_value(line));
   }
   return a;
 }

--- a/test/mrb_irep.rb
+++ b/test/mrb_irep.rb
@@ -24,7 +24,11 @@ end
 
 assert 'MrbState::RProc::MrbIrep#iseq' do
   irep = MrbState::RProc::MrbIrep.new { }
-  assert_equal [8388613, 8388649], irep.iseq
+  if MRUBY_RELEASE_NO < 20000
+    assert_equal [8388613, 8388649], irep.iseq
+  else
+    assert_equal [15, 1, 55, 1], irep.iseq
+  end
 end
 
 assert 'MrbState::RProc::MrbIrep#pool' do
@@ -50,7 +54,9 @@ assert 'MrbState::RProc::MrbIrep#lv' do
   assert_equal [], irep.lv
 
   irep = MrbState::RProc::MrbIrep.new {|a,b,c| }
-  assert_equal [{name: :a, r: 1}, {name: :b, r: 2}, {name: :c, r: 3}], irep.lv
+  lv = [{name: :a, r: 1}, {name: :b, r: 2}, {name: :c, r: 3}]
+  lv << {name: :&, r: 4} if MRUBY_RELEASE_NO >= 20000
+  assert_equal lv, irep.lv
 end
 
 assert 'MrbState::RProc::MrbIrep#filename' do
@@ -65,10 +71,18 @@ end
 
 assert 'MrbState::RProc::MrbIrep#ilen' do
   irep = MrbState::RProc::MrbIrep.new { }
-  assert_equal 2, irep.ilen
+  if MRUBY_RELEASE_NO < 20000
+    assert_equal 2, irep.ilen
+  else
+    assert_equal 4, irep.ilen
+  end
 
   irep = MrbState::RProc::MrbIrep.new {|a| }
-  assert_equal 3, irep.ilen
+  if MRUBY_RELEASE_NO < 20000
+    assert_equal 3, irep.ilen
+  else
+    assert_equal 8, irep.ilen
+  end
 end
 
 assert 'MrbState::RProc::MrbIrep#plen' do


### PR DESCRIPTION
`MrbState::RProc::MrbIrep#lines` has been acquired by `mrb_debug_get_line ()`.
Instead of being safe by this, it may be very late.

Also, if you use it with mruby's HEAD you can build but the test will fail.
I do not know where to go until mruby-2.0.1 or 2.1, so I left it as it is.
